### PR TITLE
Add WiFi fake power control

### DIFF
--- a/src/remote_main.cpp
+++ b/src/remote_main.cpp
@@ -891,7 +891,6 @@ void main_loop()
     powerswitch.scan();
     if(isFPBKeyChange) {
         isFPBKeyChange = false;
-        powerState = isFPBKeyPressed;
         #ifdef REMOTE_DBG
         if(bootFlag) {
             Serial.printf("Power change detected at boot\n");
@@ -960,7 +959,7 @@ void main_loop()
 
                 networkTimeTravel = false;
 
-                bttfn_remote_send_combined(powerState, brakeState, currSpeed);
+                fakePower(true);
 
                 #ifdef REMOTE_HAVEAUDIO
                 play_file(powerOnSnd, PA_INTRMUS|PA_ALLOWSD|PA_DYNVOL, 1.0);
@@ -996,7 +995,7 @@ void main_loop()
 
                 flushDelayedSave();
 
-                bttfn_remote_send_combined(powerState, brakeState, currSpeed);
+                fakePower(false);
 
                 #ifdef REMOTE_HAVEAUDIO
                 if(havePOFFsnd) {
@@ -3146,6 +3145,14 @@ void bttfn_remote_unregister()
     if(!bttfn_send_command(BTTFN_REMCMD_BYE, 0, 0)) {
         triggerCompleteUpdate = true;
     }
+}
+
+void fakePower(bool on)
+{
+    if(powerState != on) {
+        powerState = on;
+    }
+    bttfn_remote_send_combined(powerState, brakeState, currSpeed);
 }
 
 static void bttfn_remote_send_combined(bool powerstate, bool brakestate, uint8_t speed)

--- a/src/remote_main.h
+++ b/src/remote_main.h
@@ -127,5 +127,6 @@ void mydelay(unsigned long mydel, bool withBTTFN = false);
 
 void bttfn_loop();
 void bttfn_remote_unregister();
+void fakePower(bool on);
 
 #endif


### PR DESCRIPTION
## Summary
- expose a `fakePower()` helper to toggle Time Circuits Display fake power over BTTFN
- allow Time Circuits Display firmware to react to remote fake power commands and drive its internal switch state
- invoke the fake power helper when the physical fake-power switch GPIO changes

